### PR TITLE
Add an assertion on amount for NaN values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -600,6 +600,7 @@ class SepaTransaction {
       this.type === TransactionTypes.Transfer ? 'creditor' : 'debtor';
 
     assertions.assertSepaIdSet1(this.end2endId, 'end2endId');
+    assertions.assert(!isNaN(this.amount), 'amount is not a number');
     assertions.assertRange(this.amount, 0.01, 999999999.99, 'amount');
     assertions.assert(
       this.amount == this.amount.toFixed(2),


### PR DESCRIPTION
NaN can pass the `assertRange` validation and leads to hard to debug `'amount has too many fractional digits'` errors.

This PR check for NaN values before others assertions.