### PR TITLE
feat: handle \@

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -183,6 +183,7 @@ class SepaDocument {
         .replace(/&amp;/g, '+')
         // same for apostrophes, which are simply removed
         .replace(/'/g, ' ')
+        .replace(/@/g, '')
     );
   }
 }
@@ -616,7 +617,7 @@ class SepaTransaction {
     const pullFrom =
       this.type === TransactionTypes.Transfer ? 'creditor' : 'debtor';
 
-    this.end2endId = this.end2endId.replace('&', '+');
+    this.end2endId = this.end2endId.replace('&', '+').replace('@', '');
     assertions.assertSepaIdSet1(this.end2endId, 'end2endId');
     assertions.assert(!isNaN(this.amount), 'amount is not a number');
     assertions.assertRange(this.amount, 0.01, 999999999.99, 'amount');

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -5,7 +5,7 @@ describe('#SEPA', () => {
     const doc = new SEPA.Document('pain.008.001.02');
     doc.grpHdr.id = 'XMPL.20140201.TR0';
     doc.grpHdr.created = new Date('2019-01-01T08:00');
-    doc.grpHdr.initiatorName = 'Example & LLC';
+    doc.grpHdr.initiatorName = 'Example & LLC@';
 
     const info = doc.createPaymentInfo();
     info.collectionDate = new Date('2019-01-01T08:00');
@@ -26,7 +26,7 @@ describe('#SEPA', () => {
     tx.amount = 50.23;
     tx.currency = 'EUR';
     tx.remittanceInfo = 'INVOICE 54';
-    tx.end2endId = 'X&M.CUST487.INVOICE.54';
+    tx.end2endId = 'X&M@.CUST487.INVOICE.54';
     info.addTransaction(tx);
 
     expect(doc.toString()).toMatchSnapshot();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sepa",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Create SEPA XML for business transactions",
   "repository": {
     "url": "https://github.com/kewisch/sepa.js"


### PR DESCRIPTION
We have companies with `@` in their name, which is not necessarily handled by all the banks and leads to invalid id. According to the [documentation](https://www.europeanpaymentscouncil.eu/sites/default/files/KB/files/EPC217-08%20Draft%20Best%20Practices%20SEPA%20Requirements%20for%20Character%20Set%20v1.1.pdf), we remove this character:
<img width="681" alt="Capture d’écran 2023-05-23 à 11 47 46" src="https://github.com/kewisch/sepa.js/assets/32215310/ff43e9f2-0265-4bcb-b42c-b7ab2a107abe">
